### PR TITLE
whyred: fstab: Remove flags which are not needed

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -8,7 +8,7 @@
 # Non-A/B fstab.qcom variant
 #<src>                                   <mnt_point>        <type> <mnt_flags and options>                          <fs_mgr_flags>
 /dev/block/bootdevice/by-name/userdata   /data              f2fs   nosuid,nodev,noatime,discard,background_gc=off,fsync_mode=nobarrier   wait,quota,encryptable=footer
-/dev/block/bootdevice/by-name/userdata   /data              ext4   nosuid,nodev,barrier=1,noauto_da_alloc,discard,noatime,lazytime,errors=panic   wait,resize,check,encryptable=footer,crashcheck,quota
+/dev/block/bootdevice/by-name/userdata   /data              ext4   nosuid,nodev,barrier=1,noauto_da_alloc,discard,noatime,lazytime,errors=panic   wait,check,encryptable=footer,quota
 /devices/soc/c084000.sdhci/mmc_host*     /storage/sdcard1   vfat   nosuid,nodev                                     wait,voldmanaged=sdcard1:auto,encryptable=footer
 /dev/block/bootdevice/by-name/cust       /cust              ext4   ro,nosuid,nodev,barrier=1                        wait,check
 /dev/block/bootdevice/by-name/misc       /misc              emmc   defaults                                         defaults


### PR DESCRIPTION
03-16 08:35:13.219   592   592 E vold    : [libfs_mgr]Warning: unknown flag resize
03-16 08:35:13.219   592   592 E vold    : [libfs_mgr]Warning: unknown flag crashcheck

This is present on both ext4 and f2fs data partition, even on MIUI!

Signed-off-by: Mihran Thalhath <mihranz7@gmail.com>